### PR TITLE
Remove dependency version for managed dependencies

### DIFF
--- a/external-microservice/microservice/pom.xml
+++ b/external-microservice/microservice/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>com.example.framework</groupId>
             <artifactId>framework-lib</artifactId>
-            <version>0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The version of the library is provided in a `<dependencyManagement>` block somewhere in the parent chain of this microservice application.